### PR TITLE
Adjust candlestick axis tick placement

### DIFF
--- a/Trading_gui.py
+++ b/Trading_gui.py
@@ -267,6 +267,9 @@ def show_candlestick():
     fig.autofmt_xdate()
     ax.set_ylabel('Price')
     ax.set_title(f"{sym} Candlestick with Volume Profile")
+    ax.yaxis.set_label_position('right')
+    ax.tick_params(axis='y', labelright=True, right=True, labelleft=False, left=False)
+    ax_vp.tick_params(axis='y', labelleft=True, left=True, labelright=False, right=False)
 
     from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
     canvas = FigureCanvasTkAgg(fig, master=chart_frame)


### PR DESCRIPTION
## Summary
- move candlestick axis ticks and labels to the right-hand side of the chart
- keep the volume profile axis responsible for left-side ticks to avoid overlap

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2a7faf11c8325bad6319afb22c25d