### PR TITLE
Fix pennant detection to use bullish helper

### DIFF
--- a/pattern_scanner.py
+++ b/pattern_scanner.py
@@ -426,8 +426,8 @@ def scan_all_symbols(symbols):
                 pattern = "Inverse Head and Shoulders"
             elif detect_ascending_triangle(df):
                 pattern = "Ascending Triangle"
-            elif detect_pennant(df):
-                pattern = "Pennant"
+            elif detect_bullish_pennant(df):
+                pattern = "Bullish Pennant"
             elif detect_bullish_flag(df):
                 pattern = "Bullish Flag"
             elif detect_bullish_rectangle(df):
@@ -449,8 +449,8 @@ def scan_all_symbols(symbols):
                 pattern = "Inverse Head and Shoulders"
             elif detect_ascending_triangle(df):
                 pattern = "Ascending Triangle"
-            elif detect_pennant(df):
-                pattern = "Pennant"
+            elif detect_bullish_pennant(df):
+                pattern = "Bullish Pennant"
                 print(" Skipped: No pattern matched")
                 disqualified.append({'symbol': symbol, 'reason': 'no pattern matched', 'entry': entry, 'rr': None})
                 continue
@@ -461,8 +461,8 @@ def scan_all_symbols(symbols):
                 pattern = "Inverse Head and Shoulders"
             elif detect_ascending_triangle(df):
                 pattern = "Ascending Triangle"
-            elif detect_pennant(df):
-                pattern = "Pennant"
+            elif detect_bullish_pennant(df):
+                pattern = "Bullish Pennant"
                 print(" Skipped: No pattern matched")
                 disqualified.append({'symbol': symbol, 'reason': 'no pattern matched', 'entry': entry, 'rr': None})
                 continue
@@ -495,8 +495,8 @@ def scan_all_symbols(symbols):
                 pattern = "Inverse Head and Shoulders"
             elif detect_ascending_triangle(df):
                 pattern = "Ascending Triangle"
-            elif detect_pennant(df):
-                pattern = "Pennant"
+            elif detect_bullish_pennant(df):
+                pattern = "Bullish Pennant"
                 print(" Skipped: No pattern matched")
                 disqualified.append({'symbol': symbol, 'reason': 'no pattern matched', 'entry': entry, 'rr': None})
                 continue


### PR DESCRIPTION
## Summary
- replace pennant detection calls in the scanner with the existing `detect_bullish_pennant` helper
- update the reported pattern label to "Bullish Pennant"

## Testing
- python pattern_scanner.py *(fails: ModuleNotFoundError: No module named 'alpaca_trade_api')*


------
https://chatgpt.com/codex/tasks/task_e_68e2c5c0221883258a4a6ade44b6701c