### PR TITLE
Clamp ascending triangle detection to last 60 candles

### DIFF
--- a/pattern_scanner.py
+++ b/pattern_scanner.py
@@ -175,6 +175,8 @@ def detect_inverse_head_shoulders(df):
     return False
 
 def detect_ascending_triangle(df, window=60, tolerance=0.02, min_touches=2):
+    window = min(window, 60, len(df))
+
     highs = df['high'].tail(window).values
     lows = df['low'].tail(window).values
     closes = df['close'].tail(window).values
@@ -465,7 +467,7 @@ def _demo_ascending_triangle_detection():
         'volume': volume
     })
 
-    pattern_detected = detect_ascending_triangle(df, window=len(df), tolerance=0.02, min_touches=2)
+    pattern_detected = detect_ascending_triangle(df, window=60, tolerance=0.02, min_touches=2)
     print("Synthetic ascending triangle detected:", pattern_detected)
 
 def scan_all_symbols(symbols):


### PR DESCRIPTION
## Summary
- clamp the ascending triangle detector to analyze at most the most recent 60 candles
- update the demo call to reflect the fixed 60-candle window usage

## Testing
- python pattern_scanner.py *(fails: ModuleNotFoundError: No module named 'alpaca_trade_api')*


------
https://chatgpt.com/codex/tasks/task_e_68e2d6b4006483258cad79a67d0b6bd5