### PR TITLE
Add cup-and-handle scanner metadata and tests

### DIFF
--- a/cup_handle_scanner.py
+++ b/cup_handle_scanner.py
@@ -1,0 +1,117 @@
+"""Cup and handle pattern detection utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LinearRegression
+
+
+@dataclass
+class CupHandleHit:
+    """Container describing a detected cup and handle pattern."""
+
+    resistance: float
+    cup_depth: float
+    cup_depth_pct: float
+    handle_length: int
+    handle_pullback_pct: float
+    handle_slope: float
+
+
+_DEF_MIN_CUP_DEPTH_PCT = 0.12
+_DEF_MAX_HANDLE_PULLBACK_PCT = 0.18
+_DEF_HANDLE_SLOPE_BOUNDS = (-0.25, 0.05)
+
+
+def detect_cup_and_handle(
+    df: pd.DataFrame,
+    *,
+    cup_window: int = 60,
+    handle_window: int = 15,
+    tolerance: float = 0.1,
+    min_cup_depth_pct: float | None = None,
+    max_handle_pullback_pct: float | None = None,
+    handle_slope_bounds: tuple[float, float] | None = None,
+) -> Optional[CupHandleHit]:
+    """Return a :class:`CupHandleHit` if a pattern is detected.
+
+    The logic mirrors the historical boolean implementation but now captures
+    richer metrics so downstream consumers can surface more insightful context
+    without re-computing them.
+    """
+
+    if df is None or df.empty:
+        return None
+
+    required_cols = {"close"}
+    if not required_cols.issubset(df.columns):
+        return None
+
+    min_cup_depth_pct = _DEF_MIN_CUP_DEPTH_PCT if min_cup_depth_pct is None else min_cup_depth_pct
+    max_handle_pullback_pct = (
+        _DEF_MAX_HANDLE_PULLBACK_PCT if max_handle_pullback_pct is None else max_handle_pullback_pct
+    )
+    handle_slope_bounds = _DEF_HANDLE_SLOPE_BOUNDS if handle_slope_bounds is None else handle_slope_bounds
+
+    window = cup_window + handle_window
+    if window <= 0 or len(df) < window:
+        return None
+
+    closes = df["close"].tail(window)
+    if closes.isnull().any():
+        return None
+
+    cup = closes.iloc[:cup_window]
+    handle = closes.iloc[cup_window:]
+    if cup.empty or handle.empty:
+        return None
+
+    midpoint = cup_window // 2
+    left = cup.iloc[: midpoint or 1]
+    right = cup.iloc[midpoint:]
+    if left.empty or right.empty:
+        return None
+
+    left_peak = float(left.max())
+    right_peak = float(right.max())
+    resistance = float(np.mean([left_peak, right_peak]))
+    if resistance <= 0:
+        return None
+
+    peak_diff = abs(left_peak - right_peak) / resistance
+    if peak_diff > tolerance:
+        return None
+
+    cup_min = float(cup.min())
+    cup_depth = float(resistance - cup_min)
+    if cup_depth <= 0:
+        return None
+
+    cup_depth_pct = cup_depth / resistance
+    if cup_depth_pct < min_cup_depth_pct:
+        return None
+
+    x = np.arange(handle_window).reshape(-1, 1)
+    model = LinearRegression().fit(x, handle.to_numpy())
+    handle_slope = float(model.coef_[0])
+
+    slope_low, slope_high = handle_slope_bounds
+    if not (slope_low <= handle_slope <= slope_high):
+        return None
+
+    handle_min = float(handle.min())
+    handle_pullback = (resistance - handle_min) / resistance
+    if handle_pullback < 0 or handle_pullback > max_handle_pullback_pct:
+        return None
+
+    return CupHandleHit(
+        resistance=resistance,
+        cup_depth=cup_depth,
+        cup_depth_pct=cup_depth_pct,
+        handle_length=int(handle_window),
+        handle_pullback_pct=float(handle_pullback),
+        handle_slope=handle_slope,
+    )

--- a/tests/test_cup_handle_scanner.py
+++ b/tests/test_cup_handle_scanner.py
@@ -1,0 +1,38 @@
+import pandas as pd
+
+from cup_handle_scanner import CupHandleHit, detect_cup_and_handle
+
+
+def _make_close_series(values):
+    index = pd.date_range("2024-01-01", periods=len(values), freq="D")
+    return pd.DataFrame({"close": values}, index=index)
+
+
+def test_detect_cup_and_handle_returns_hit_with_metrics():
+    cup_left = [100, 98, 96, 94, 92, 90, 88, 86, 84, 82]
+    cup_right = [82, 84, 86, 88, 90, 92, 94, 96, 98, 100]
+    cup = cup_left + cup_right
+    handle = [99.0, 98.8, 98.6, 98.4, 98.2]
+    closes = cup + handle
+
+    df = _make_close_series(closes)
+
+    hit = detect_cup_and_handle(df, cup_window=len(cup), handle_window=len(handle))
+
+    assert isinstance(hit, CupHandleHit)
+    assert hit.resistance > hit.cup_depth
+    assert 0 < hit.cup_depth_pct < 1
+    assert hit.handle_length == len(handle)
+    assert 0 <= hit.handle_pullback_pct < 0.05
+    assert hit.handle_slope < 0
+
+
+def test_detect_cup_and_handle_rejects_shallow_cup():
+    shallow_cup = [100, 99.5, 99, 98.5, 98, 98.5, 99, 99.5]
+    handle = [99.4, 99.2, 99.1]
+    closes = shallow_cup + handle
+    df = _make_close_series(closes)
+
+    hit = detect_cup_and_handle(df, cup_window=len(shallow_cup), handle_window=len(handle))
+
+    assert hit is None


### PR DESCRIPTION
## Summary
- add a dedicated cup and handle scanner that returns rich pattern metadata
- surface cup and handle hit details in the pattern scanner output
- cover the new scanner logic with unit tests

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68e30cca47008325aa3c69197518f435