### PR TITLE
Fix double bottom scanner column selection bug

### DIFF
--- a/double_bottom_scanner.py
+++ b/double_bottom_scanner.py
@@ -92,8 +92,8 @@ def scan_double_bottoms(
     if df is None or df.empty:
         return []
 
-    required_cols = {"high", "low", "close", "volume"}
-    if not required_cols.issubset(df.columns):
+    required_cols = ["high", "low", "close", "volume"]
+    if not set(required_cols).issubset(df.columns):
         return []
 
     n_rows = len(df)


### PR DESCRIPTION
## Summary
- replace the set of required columns in the double bottom scanner with a list so pandas indexing works
- keep the subset validation while avoiding the set indexer error encountered during scans

## Testing
- pytest *(fails: missing pandas dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e30fe03290832580feaf26feaf6216