### PR TITLE
Silence watchlist refresh info dialog when shared source missing

### DIFF
--- a/Trading_gui.py
+++ b/Trading_gui.py
@@ -397,10 +397,8 @@ def refresh_watchlist():
 
             if not shared_found:
                 if os.path.exists(local_watchlist):
-                    messagebox.showinfo(
-                        "Reload Watchlist",
-                        "Shared watchlist not found. Using existing local copy.",
-                    )
+                    print(
+                        "[Watchlist] Shared watchlist not found. Using existing local copy.")
                 else:
                     messagebox.showerror(
                         "Reload Watchlist",


### PR DESCRIPTION
## Summary
- remove the modal info dialog when shared watchlist.csv cannot be found during refresh
- keep the fallback to the existing local watchlist while logging the condition to stdout

## Testing
- pytest *(fails: missing pandas dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e31724ffc083258b6f40e6379d909e