### PR TITLE
Align candlestick layout with right-side volume profile

### DIFF
--- a/Trading_gui.py
+++ b/Trading_gui.py
@@ -259,7 +259,6 @@ def show_candlestick():
     import matplotlib.dates as mdates
     import matplotlib.ticker as mticker
     import numpy as np
-    from mpl_toolkits.axes_grid1 import make_axes_locatable
 
     sel = tree.selection()
     if not sel:
@@ -303,13 +302,12 @@ def show_candlestick():
     norm_vol = volume_by_price / volume_by_price.max()
 
     fig = plt.figure(figsize=(12, 6))
-    gs = fig.add_gridspec(3, 1, height_ratios=[3, 1, 1], hspace=0.05)
+    gs = fig.add_gridspec(3, 2, width_ratios=[20, 5], height_ratios=[3, 1, 1], hspace=0.05, wspace=0.05)
 
     ax_price = fig.add_subplot(gs[0, 0])
-    divider = make_axes_locatable(ax_price)
-    ax_vp = divider.append_axes("right", size=1.2, pad=0.05, sharey=ax_price)
     ax_volume = fig.add_subplot(gs[1, 0], sharex=ax_price)
     ax_rsi = fig.add_subplot(gs[2, 0], sharex=ax_price)
+    ax_vp = fig.add_subplot(gs[:, 1], sharey=ax_price)
 
     for t, o, h, l, c in ohlc:
         color = 'green' if c >= o else 'red'


### PR DESCRIPTION
## Summary
- align the candlestick, volume, and RSI panels by placing them in a shared column
- move the volume profile into a dedicated right-side column that spans the stacked panels

## Testing
- python -m compileall Trading_gui.py

------
https://chatgpt.com/codex/tasks/task_e_68e5b2f0eee08325ba9546f4f9c0f443