### PR TITLE
Fix volume profile index for chart rendering

### DIFF
--- a/Trading_gui.py
+++ b/Trading_gui.py
@@ -310,7 +310,7 @@ def show_candlestick():
     # actual price range traded during that candle.  Distributing volume across
     # the high/low range ties the histogram bars to the price axis instead of
     # assigning all of the volume to the closing price.
-    volume_by_price = pd.Series(0.0, index=price_index)
+    volume_by_price = pd.Series(0.0, index=price_levels)
 
     bin_low_edges = bins[:-1]
     bin_high_edges = bins[1:]


### PR DESCRIPTION
## Summary
- reference the calculated price level bins when building the volume profile histogram

## Testing
- pytest *(fails: missing pandas and numpy dependencies in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5d2850f64832592d1ed0030f23fd8