### PR TITLE
Add support/resistance scanner with heavy-volume validation

### DIFF
--- a/pattern_scanner.py
+++ b/pattern_scanner.py
@@ -134,6 +134,9 @@ PATTERN_ALIASES = {
     "bullish rectangle": "Bullish Rectangle",
     "rounding bottom": "Rounding Bottom",
     "breakaway gap": "Breakaway Gap",
+    "support and resistance": "Support and Resistance",
+    "support & resistance": "Support and Resistance",
+    "support resistance": "Support and Resistance",
 }
 
 AVAILABLE_PATTERNS = tuple(dict.fromkeys(PATTERN_ALIASES.values()))
@@ -210,6 +213,16 @@ class BreakawayGapPattern:
     prev_close: float
     curr_open: float
     curr_close: float
+
+
+@dataclass
+class SupportResistancePattern:
+    support: float
+    resistance: float
+    support_touch_count: int
+    resistance_touch_count: int
+    support_heavy_volume_ratio: float
+    resistance_heavy_volume_ratio: float
 
 
 @dataclass
@@ -1725,6 +1738,15 @@ def _score_breakaway_gap(pattern: BreakawayGapPattern) -> float:
     return _clamp(score, 0.0, 0.9)
 
 
+def _score_support_resistance(pattern: SupportResistancePattern) -> float:
+    score = 0.55
+    score += _clamp(pattern.support_touch_count * 0.03, 0.0, 0.15)
+    score += _clamp(pattern.resistance_touch_count * 0.03, 0.0, 0.15)
+    score += _clamp((pattern.support_heavy_volume_ratio - 1.0) * 0.2, 0.0, 0.08)
+    score += _clamp((pattern.resistance_heavy_volume_ratio - 1.0) * 0.2, 0.0, 0.08)
+    return _clamp(score, 0.0, 0.92)
+
+
 def _normalize_pattern_name(name: str) -> Optional[str]:
     normalized = PATTERN_ALIASES.get(name.strip().lower())
     return normalized
@@ -1783,6 +1805,11 @@ def _collect_pattern_candidates(
     if gap and _should_include("Breakaway Gap"):
         confidence = _score_breakaway_gap(gap)
         candidates.append(PatternCandidate("Breakaway Gap", confidence, gap))
+
+    support_resistance = detect_support_resistance_volume(df)
+    if support_resistance and _should_include("Support and Resistance"):
+        confidence = _score_support_resistance(support_resistance)
+        candidates.append(PatternCandidate("Support and Resistance", confidence, support_resistance))
 
     candidates.sort(key=lambda candidate: candidate.confidence, reverse=True)
     return candidates
@@ -1849,6 +1876,14 @@ def _print_pattern_details(candidate: PatternCandidate) -> None:
             f"Prev Close: {details.prev_close:.2f}, "
             f"Open: {details.curr_open:.2f}, Close: {details.curr_close:.2f}, "
             f"Gap: {gap_pct * 100:.1f}%, Body: {body_pct * 100:.1f}%"
+        )
+    elif isinstance(details, SupportResistancePattern):
+        print(
+            "  Support/Resistance details → "
+            f"Support: {details.support:.2f} ({details.support_touch_count} touches), "
+            f"Resistance: {details.resistance:.2f} ({details.resistance_touch_count} touches), "
+            f"Volume ratios S/R: {details.support_heavy_volume_ratio:.2f}x/"
+            f"{details.resistance_heavy_volume_ratio:.2f}x"
         )
 
 
@@ -2404,6 +2439,69 @@ def detect_breakaway_gap(
         )
 
     return None
+
+
+
+def detect_support_resistance_volume(
+    df,
+    window: int = 120,
+    level_tolerance: float = 0.02,
+    min_touches: int = 3,
+    heavy_volume_multiplier: float = 1.3,
+) -> Optional[SupportResistancePattern]:
+    required = ["high", "low", "close", "volume"]
+    if len(df) < max(window, 20) or any(col not in df.columns for col in required):
+        return None
+
+    segment = df.tail(window).copy()
+    segment = segment.dropna(subset=required)
+    if len(segment) < 20:
+        return None
+
+    zone_size = min(len(segment), max(min_touches * 3, 12))
+    low_zone = segment.nsmallest(zone_size, "low")
+    high_zone = segment.nlargest(zone_size, "high")
+
+    support = float((low_zone["low"] * low_zone["volume"]).sum() / max(low_zone["volume"].sum(), 1e-6))
+    resistance = float((high_zone["high"] * high_zone["volume"]).sum() / max(high_zone["volume"].sum(), 1e-6))
+    if support <= 0 or resistance <= 0 or resistance <= support:
+        return None
+
+    support_band = max(support * level_tolerance, 1e-6)
+    resistance_band = max(resistance * level_tolerance, 1e-6)
+
+    support_touches = (segment["low"] <= support + support_band) & (segment["low"] >= support - support_band)
+    resistance_touches = (segment["high"] >= resistance - resistance_band) & (segment["high"] <= resistance + resistance_band)
+
+    support_touch_count = int(support_touches.sum())
+    resistance_touch_count = int(resistance_touches.sum())
+    if support_touch_count < min_touches or resistance_touch_count < min_touches:
+        return None
+
+    avg_volume = float(segment["volume"].mean())
+    if not np.isfinite(avg_volume) or avg_volume <= 0:
+        return None
+
+    support_touch_volume = float(segment.loc[support_touches, "volume"].mean()) if support_touch_count else 0.0
+    resistance_touch_volume = float(segment.loc[resistance_touches, "volume"].mean()) if resistance_touch_count else 0.0
+
+    support_heavy_volume_ratio = support_touch_volume / avg_volume
+    resistance_heavy_volume_ratio = resistance_touch_volume / avg_volume
+
+    if (
+        support_heavy_volume_ratio < heavy_volume_multiplier
+        and resistance_heavy_volume_ratio < heavy_volume_multiplier
+    ):
+        return None
+
+    return SupportResistancePattern(
+        support=support,
+        resistance=resistance,
+        support_touch_count=support_touch_count,
+        resistance_touch_count=resistance_touch_count,
+        support_heavy_volume_ratio=float(support_heavy_volume_ratio),
+        resistance_heavy_volume_ratio=float(resistance_heavy_volume_ratio),
+    )
 
 
 def volume_trend_up(df, window=60, slope: Optional[float] = None):

--- a/tests/test_support_resistance_scanner.py
+++ b/tests/test_support_resistance_scanner.py
@@ -1,0 +1,63 @@
+from tests.test_pattern_scanner import _install_stub_modules
+
+_install_stub_modules()
+
+import pandas as pd
+
+from pattern_scanner import (
+    SupportResistancePattern,
+    _collect_pattern_candidates,
+    detect_support_resistance_volume,
+)
+
+
+def _build_frame_with_level_volume_spikes() -> pd.DataFrame:
+    closes = [106 + (i % 5) * 2 for i in range(120)]
+    lows = [c - 2 for c in closes]
+    highs = [c + 2 for c in closes]
+    volume = [1_000_000] * len(closes)
+
+    support_touch_indices = [20, 45, 70, 95]
+    resistance_touch_indices = [30, 60, 90, 110]
+
+    for idx in support_touch_indices:
+        lows[idx] = 99.5
+        closes[idx] = 100.3
+        highs[idx] = 102.0
+        volume[idx] = 4_000_000
+
+    for idx in resistance_touch_indices:
+        highs[idx] = 121.5
+        closes[idx] = 120.8
+        lows[idx] = 118.5
+        volume[idx] = 3_800_000
+
+    return pd.DataFrame(
+        {
+            "open": closes,
+            "high": highs,
+            "low": lows,
+            "close": closes,
+            "volume": volume,
+        }
+    )
+
+
+def test_detect_support_resistance_volume_identifies_levels_with_heavy_volume():
+    df = _build_frame_with_level_volume_spikes()
+
+    pattern = detect_support_resistance_volume(df)
+
+    assert isinstance(pattern, SupportResistancePattern)
+    assert pattern.support_touch_count >= 3
+    assert pattern.resistance_touch_count >= 3
+    assert pattern.support_heavy_volume_ratio > 1.3 or pattern.resistance_heavy_volume_ratio > 1.3
+
+
+def test_collect_candidates_includes_support_resistance_pattern():
+    df = _build_frame_with_level_volume_spikes()
+
+    candidates = _collect_pattern_candidates(df, ["Support and Resistance"])
+
+    assert candidates
+    assert candidates[0].name == "Support and Resistance"


### PR DESCRIPTION
### Motivation
- Provide a detector that finds major support and resistance zones and validates heavy volume at those levels so the scanner can surface levels with conviction.
- Allow the new pattern to participate in the existing pattern ranking and watchlist flow alongside other chart patterns.

### Description
- Added pattern aliases for `Support and Resistance` and a new `SupportResistancePattern` dataclass. 
- Implemented `detect_support_resistance_volume(...)` which identifies S/R zones over a recent window, counts touches, and requires a heavy-volume multiplier to return a hit. 
- Added `_score_support_resistance(...)`, integrated the detector into `_collect_pattern_candidates`, and added detail printing in `_print_pattern_details`. 
- Added unit tests in `tests/test_support_resistance_scanner.py` to validate direct detection and inclusion in the candidate collection. 

### Testing
- Ran `pytest -q tests/test_support_resistance_scanner.py tests/test_pattern_scanner.py` which passed. 
- Ran the full test suite with `pytest -q` and all tests passed (36 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b5f8376c88325a07127ff65d0acf6)